### PR TITLE
fix(backend): revert `async` keyword removal

### DIFF
--- a/backend/src/routes/health.rs
+++ b/backend/src/routes/health.rs
@@ -6,6 +6,8 @@ pub struct Health {
     status: &'static str,
 }
 
-pub const fn health() -> Json<Health> {
+// Needs async for axum to implement trait `Handler<_, _>`
+#[allow(clippy::unused_async)]
+pub async fn health() -> Json<Health> {
     Json(Health { status: "ok" })
 }


### PR DESCRIPTION
Making function `health` synchronous removed the ability for axum routing to automatically implement trait `Handler<_, _>`. Add Clippy ignore and revert change.